### PR TITLE
Fix bugs in the STM

### DIFF
--- a/Concurrent.xcodeproj/project.pbxproj
+++ b/Concurrent.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		826B55951D9A1B0500FC5257 /* STMSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826B55941D9A1B0500FC5257 /* STMSpec.swift */; };
+		826B55961D9A1B0500FC5257 /* STMSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826B55941D9A1B0500FC5257 /* STMSpec.swift */; };
+		826B55971D9A1B0500FC5257 /* STMSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826B55941D9A1B0500FC5257 /* STMSpec.swift */; };
 		82AA04071D7B206300DD3037 /* Concurrent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82AA03FE1D7B206300DD3037 /* Concurrent.framework */; };
 		82AA04281D7B210700DD3037 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82AA03F41D7B08CB00DD3037 /* SwiftCheck.framework */; };
 		82AA04651D7B2D6700DD3037 /* ChanSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AA045F1D7B2D6700DD3037 /* ChanSpec.swift */; };
@@ -208,6 +211,7 @@
 
 /* Begin PBXFileReference section */
 		821BEE5F1D8EFDA5009F8D58 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = SOURCE_ROOT; };
+		826B55941D9A1B0500FC5257 /* STMSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = STMSpec.swift; path = Sources/STMSpec.swift; sourceTree = SOURCE_ROOT; };
 		82AA03FE1D7B206300DD3037 /* Concurrent.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Concurrent.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82AA04061D7B206300DD3037 /* Concurrent-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Concurrent-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		82AA041E1D7B206C00DD3037 /* Concurrent.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Concurrent.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -360,6 +364,7 @@
 				82AA04611D7B2D6700DD3037 /* MVarSpec.swift */,
 				82AA04631D7B2D6700DD3037 /* SVarSpec.swift */,
 				82AA04641D7B2D6700DD3037 /* TMVarSpec.swift */,
+				826B55941D9A1B0500FC5257 /* STMSpec.swift */,
 				8434F99019E9CD76008D9909 /* Supporting Files */,
 			);
 			path = ConcurrentTests;
@@ -756,6 +761,7 @@
 				82AA04761D7B2D6700DD3037 /* TMVarSpec.swift in Sources */,
 				82AA04731D7B2D6700DD3037 /* SVarSpec.swift in Sources */,
 				82AA046A1D7B2D6700DD3037 /* ConcurrentSpec.swift in Sources */,
+				826B55971D9A1B0500FC5257 /* STMSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -810,6 +816,7 @@
 				82AA04741D7B2D6700DD3037 /* TMVarSpec.swift in Sources */,
 				82AA04711D7B2D6700DD3037 /* SVarSpec.swift in Sources */,
 				82AA04681D7B2D6700DD3037 /* ConcurrentSpec.swift in Sources */,
+				826B55951D9A1B0500FC5257 /* STMSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -843,6 +850,7 @@
 				82AA04751D7B2D6700DD3037 /* TMVarSpec.swift in Sources */,
 				82AA04721D7B2D6700DD3037 /* SVarSpec.swift in Sources */,
 				82AA04691D7B2D6700DD3037 /* ConcurrentSpec.swift in Sources */,
+				826B55961D9A1B0500FC5257 /* STMSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/STM.swift
+++ b/Sources/STM.swift
@@ -34,13 +34,9 @@ public struct STM<T> {
 	/// of the `orElse`. Otherwise, if the first action retries, then the second
 	/// action is tried in its place. If both actions retry then the `orElse` as
 	/// a whole retries.
-	public func orElse(_ b : STM<T>) -> STM<T>  {
+	public func orElse(_ b : STM<T>) throws -> STM<T>  {
 		return STM { trans in
-			do {
-				return try trans.orElse(self.unSTM, q: b.unSTM)
-			} catch _ {
-				fatalError()
-			}
+			return try trans.orElse(self.unSTM, q: b.unSTM)
 		}
 	}
 	

--- a/Sources/STM.swift
+++ b/Sources/STM.swift
@@ -28,7 +28,7 @@ public struct STM<T> {
 		}
 	}
 	
-	/// Compose two alternative STM actions (GHC only). 
+	/// Compose two alternative STM actions. 
 	///
 	/// If the first action completes without retrying then it forms the result
 	/// of the `orElse`. Otherwise, if the first action retries, then the second

--- a/Sources/STMSpec.swift
+++ b/Sources/STMSpec.swift
@@ -1,0 +1,94 @@
+//
+//  STMSpec.swift
+//  Concurrent
+//
+//  Created by Robert Widmann on 9/26/16.
+//  Copyright © 2016 TypeLift. All rights reserved.
+//
+
+import Concurrent
+import XCTest
+
+let initTVars = STM<(TVar<Int>, TVar<Int>)>.pure(TVar(0), TVar(0))
+
+func optionOne(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return v1.read().flatMap({ x in
+		return v1.write(x + 10)
+	}).then(STM.retry())
+}
+
+func optionTwo(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return v2.read().flatMap { x in
+		return v2.write(x + 10)
+	}
+}
+
+func elseTestA(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return try! optionOne(v1, v2).orElse(optionTwo(v1, v2))
+}
+
+func elseTestB(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return try! optionTwo(v1, v2).orElse(optionOne(v1, v2))
+}
+
+func elseTestC(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return try! optionTwo(v1, v2).orElse(optionTwo(v1, v2))
+}
+
+func elseTestD(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return try! optionOne(v1, v2).orElse(try! optionOne(v1, v2).orElse(optionTwo(v1, v2)))
+}
+
+func elseTestE(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<()> {
+	return try! optionOne(v1, v2).orElse(optionTwo(v1, v2)).orElse(optionTwo(v1, v2))
+}
+
+func snapshot(_ v1 : TVar<Int>, _ v2 : TVar<Int>) -> STM<(Int, Int)> {
+	return v1.read().flatMap { s1 in
+		return v2.read().flatMap { s2 in
+			return STM<(Int, Int)>.pure((s1, s2))
+		}
+	}
+}
+
+class STMSpec : XCTestCase {
+	func testMain() {
+
+		let (sv1, sv2) = initTVars.atomically()
+
+		_ = elseTestA(sv1, sv2).atomically()
+		_ = {
+			let vs = snapshot(sv1, sv2).atomically()
+			XCTAssert(vs.0 == 0)
+			XCTAssert(vs.1 == 10)
+		}()
+
+		_ = elseTestB(sv1, sv2).atomically()
+		_ = {
+			let vs = snapshot(sv1, sv2).atomically()
+			XCTAssert(vs.0 == 0)
+			XCTAssert(vs.1 == 20)
+		}()
+
+		_ = elseTestC(sv1, sv2).atomically()
+		_ = {
+			let vs = snapshot(sv1, sv2).atomically()
+			XCTAssert(vs.0 == 0)
+			XCTAssert(vs.1 == 30)
+		}()
+
+		_ = elseTestD(sv1, sv2).atomically()
+		_ = {
+			let vs = snapshot(sv1, sv2).atomically()
+			XCTAssert(vs.0 == 0)
+			XCTAssert(vs.1 == 40)
+		}()
+
+		_ = elseTestE(sv1, sv2).atomically()
+		_ = {
+			let vs = snapshot(sv1, sv2).atomically()
+			XCTAssert(vs.0 == 0)
+			XCTAssert(vs.1 == 50)
+		}()
+	}
+}

--- a/Sources/TBQueue.swift
+++ b/Sources/TBQueue.swift
@@ -90,7 +90,7 @@ public struct TBQueue<A> {
 	/// Uses an atomic transaction to read the next value from the receiver
 	/// without blocking or retrying on failure.
 	public func tryRead() -> STM<Optional<A>> {
-		return self.read().fmap(Optional.some).orElse(STM<A?>.pure(.none))
+		return try! self.read().fmap(Optional.some).orElse(STM<A?>.pure(.none))
 	}
 
 	/// Uses an atomic transaction to get the next value from the receiver 

--- a/Sources/TQueue.swift
+++ b/Sources/TQueue.swift
@@ -59,7 +59,7 @@ public struct TQueue<A> {
 	/// Uses an atomic transaction to read the next value from the receiver
 	/// without blocking or retrying on failure.
 	public func tryRead() -> STM<Optional<A>> {
-		return self.read().fmap(Optional.some).orElse(STM<A?>.pure(.none))
+		return try! self.read().fmap(Optional.some).orElse(STM<A?>.pure(.none))
 	}
 
 	/// Uses an atomic transaction to get the next value from the receiver

--- a/Sources/TVar.swift
+++ b/Sources/TVar.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 TypeLift. All rights reserved.
 //
 
-/// A `TVar` (read: Transactional Variabe) is a shared memory location that 
+/// A `TVar` (read: Transactional Variable) is a shared memory location that 
 /// supports atomic memory transactions.
 public struct TVar<T> : Comparable, Hashable {
 	internal var value : TVarType<T>

--- a/Sources/Transactions.swift
+++ b/Sources/Transactions.swift
@@ -14,49 +14,47 @@
 	import Darwin
 #endif
 
-internal final class Entry<T> {
-	let oldValue : TVarType<T>
-	var location : TVar<T>
-	var _newValue : TVarType<T>
+internal final class Entry {
+	let ident : ObjectIdentifier
+	let oldValue : TVarType<Any>
+	var location : TVar<Any>
+	var _newValue : TVarType<Any>
 	let hasOldValue : Bool
 	
 	var isValid : Bool {
 		return !hasOldValue || location.value == self.oldValue
 	}
 	
-	convenience init(_ location : TVar<T>) {
+	convenience init<T>(_ location : TVar<T>) {
 		self.init(location, location.value, false)
 	}
 	
-	convenience init(_ location : TVar<T>, _ value : TVarType<T>) {
+	convenience init<T>(_ location : TVar<T>, _ value : TVarType<T>) {
 		self.init(location, value, true)
 	}
 	
-	init(_ location : TVar<T>, _ value : TVarType<T>, _ valid : Bool) {
-		self.location = location
-		self.oldValue = location.value
-		self._newValue = value
+	init<T>(_ location : TVar<T>, _ value : TVarType<T>, _ valid : Bool) {
+		self.ident = ObjectIdentifier(T.self)
+		self.location = location.upCast
+		self.oldValue = location.value.upCast
+		self._newValue = value.upCast
 		self.hasOldValue = valid
 	}
 	
-	private init(_ oldValue : TVarType<T>, _ location : TVar<T>, _ value : TVarType<T>, _ valid : Bool) {
-		self.location = location
-		self.oldValue = oldValue
-		self._newValue = value
+	private init<T>(_ ident : ObjectIdentifier, _ oldValue : TVarType<T>, _ location : TVar<T>, _ value : TVarType<T>, _ valid : Bool) {
+		self.ident = ident
+		self.location = location.upCast
+		self.oldValue = oldValue.upCast
+		self._newValue = value.upCast
 		self.hasOldValue = valid
 	}
 	
-	func mergeNested(_ e : Entry<T>) {
+	func mergeNested(_ e : Entry) {
 		e._newValue = self._newValue
 	}
 	
 	func commit() {
 		self.location.value = self._newValue
-	}
-	
-	// HACK: bridge-all-the-things-to-Any makes this a legal transformation.
-	var upCast : Entry<Any> {
-		return Entry<Any>(self.oldValue.upCast, self.location.upCast, self._newValue.upCast, self.hasOldValue)
 	}
 }
 
@@ -72,19 +70,21 @@ private var _current : Any? = nil
 internal final class TLog {
 	lazy var locker = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: MemoryLayout<pthread_mutex_t>.size)
 	lazy var cond = UnsafeMutablePointer<pthread_cond_t>.allocate(capacity: MemoryLayout<pthread_mutex_t>.size)
-	
+
 	let outer : TLog?
-	var log : Dictionary<TVar<Any>, Entry<Any>> = [:]
+	var log : Dictionary<Int, Entry> = [:]
 	
 	var isValid : Bool {
 		return self.log.values.reduce(true, { $0 && $1.isValid }) && (outer == nil || outer!.isValid)
 	}
 	
-	convenience init() {
-		self.init(outer: nil)
+	init() {
+		self.outer = nil
+		pthread_mutex_init(self.locker, nil)
+		pthread_cond_init(self.cond, nil)
 	}
 	
-	init(outer : TLog?) {
+	init(outer : TLog) {
 		self.outer = outer
 		pthread_mutex_init(self.locker, nil)
 		pthread_cond_init(self.cond, nil)
@@ -95,14 +95,15 @@ internal final class TLog {
 	}
 	
 	func readTVar<T>(_ location : TVar<T>) -> T {
-		if let entry = self.log[location.upCast] {
-			return entry._newValue.retrieve as! T
+		if let entry = self.log[location.hashValue] {
+			precondition(ObjectIdentifier.init(T.self) == entry.ident, "Type \(T.self) does not match.")
+			return entry._newValue._val() as! T
 		} else if let out = outer {
 			return out.readTVar(location)
 		} else {
 			let entry = Entry(location)
-			log[location.upCast] = entry.upCast
-			return entry.oldValue.retrieve
+			log[location.hashValue] = entry
+			return entry.oldValue._val() as! T
 		}
 	}
 	
@@ -128,21 +129,22 @@ internal final class TLog {
 	}
 	
 	func writeTVar<T>(_ location : TVar<T>, value : TVarType<T>) {
-		if let entry = self.log[location.upCast] {
+		if let entry = self.log[location.hashValue] {
+			precondition(ObjectIdentifier(T.self) == entry.ident)
 			entry._newValue = value.upCast
 		} else {
-			let entry = Entry(location)
-			log[location.upCast] = entry.upCast
+			let entry = Entry(location, value)
+			log[location.hashValue] = entry
 		}
 	}
 	
 	func mergeNested() {
 		if let out = self.outer {
 			for innerEntry in log.values {
-				if let outerE = out.log[innerEntry.location] {
+				if let outerE = out.log[innerEntry.location.hashValue] {
 					innerEntry.mergeNested(outerE)
 				} else {
-					out.log[innerEntry.location] = innerEntry
+					out.log[innerEntry.location.hashValue] = innerEntry
 				}
 			}
 		}


### PR DESCRIPTION
Previously the `upcast` nonsense would change the identity of the TVar in the middle of the computation so as long as you had the transaction log for a computation it would do the right thing, but the second you tried to interact imperatively the TVars would lose their stored values - which kinda defeats the point of them being variables.  This redoes the logic to make a series of - what I hope are - safe assumptions about type layout.  

We're still type safe, we're just checking a lot of it by hand now.