### PR TITLE
Fixed hang when compiled with Release configuration

### DIFF
--- a/Sources/Transactions.swift
+++ b/Sources/Transactions.swift
@@ -167,8 +167,8 @@ internal final class TLog {
 
 	static func atomically<T>(_ p : (TLog) throws -> T) throws -> T {
 		let trans = TLog()
-        let transactionEnterSucceed = STMCurrentTransaction.tryPut(trans)
-        precondition(transactionEnterSucceed, "Transaction already running on current thread")
+		let transactionEnterSucceed = STMCurrentTransaction.tryPut(trans)
+		precondition(transactionEnterSucceed, "Transaction already running on current thread")
 		defer {
 			_ = STMCurrentTransaction.take()
 		}

--- a/Sources/Transactions.swift
+++ b/Sources/Transactions.swift
@@ -167,7 +167,8 @@ internal final class TLog {
 
 	static func atomically<T>(_ p : (TLog) throws -> T) throws -> T {
 		let trans = TLog()
-		assert(STMCurrentTransaction.tryPut(trans), "Transaction already running on current thread")
+        let transactionEnterSucceed = STMCurrentTransaction.tryPut(trans)
+        precondition(transactionEnterSucceed, "Transaction already running on current thread")
 		defer {
 			_ = STMCurrentTransaction.take()
 		}


### PR DESCRIPTION
Assertion conditions are `@autoclosure`s which aren't executed when compiled in Release mode.
This led to an infinite hang during execution of the `atomically()` method.