### PR TITLE
Fix project name in Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Installation
 
 #### Swift Package Manager
 
-- Add SwiftCheck to your `Package.swift` file's dependencies section:
+- Add Concurrent to your `Package.swift` file's dependencies section:
 
 ```
 .Package(url: "https://github.com/typelift/Concurrent.git", versions: Version(0,4,0)..<Version(1,0,0))

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Installation
 - Add Concurrent to your `Package.swift` file's dependencies section:
 
 ```
-.Package(url: "https://github.com/typelift/Concurrent.git", versions: Version(0,4,0)..<Version(1,0,0))
+.package(url: "https://github.com/typelift/Concurrent.git", "0.4.0"..<"1.0.0")
 ```
 
 #### Carthage


### PR DESCRIPTION
Replaces "SwiftCheck" with "Concurrent" in the Swift Package Manager Installation instructions.